### PR TITLE
feature: added a checkbox that adds an OpenJD step to convert image sequences with ffmpeg

### DIFF
--- a/src/deadline/ae_submitter/UI/AESubmitterUI.jsx
+++ b/src/deadline/ae_submitter/UI/AESubmitterUI.jsx
@@ -69,6 +69,7 @@ function __generateSubmitterUI() {
     var initExportAsXml = dcUtil.parseBool(dcSettings.getIniSetting("ExportAsXml", "false"));
     var initDeleteTempXml = dcUtil.parseBool(dcSettings.getIniSetting("DeleteTempXml", "false"));
     var initUseCompFrameRange = dcUtil.parseBool(dcSettings.getIniSetting("UseCompFrame", "false"));
+    var initConvertToMov = dcUtil.parseBool(dcSettings.getIniSetting("ConvertToMov", "false"));
     var initFirstAndLast = null;
     if (!initUseCompFrameRange) {
         initFirstAndLast = false;
@@ -482,8 +483,12 @@ function __generateSubmitterUI() {
         submitEntireQueueGroup.multiProcess.helpTip = 'Enable to use multiple processes to render multiple frames simultaneously (After Effects CS3 and later).';
         submitEntireQueueGroup.submitScene = submitEntireQueueGroup.add('checkbox', undefined, 'Submit Project File With Job');
         submitEntireQueueGroup.submitScene.value = initSubmitScene;
-        submitEntireQueueGroup.submitScene.size = CHECKBOX_D_SIZE;
+        submitEntireQueueGroup.submitScene.size = CHECKBOX_B_SIZE;
         submitEntireQueueGroup.submitScene.helpTip = 'If enabled, the After Effects Project File will be submitted with the job.';
+        submitEntireQueueGroup.convertToMov = submitEntireQueueGroup.add('checkbox', undefined, 'Convert to Mov');
+        submitEntireQueueGroup.convertToMov.value = initConvertToMov;
+        submitEntireQueueGroup.convertToMov.size = CHECKBOX_D_SIZE;
+        submitEntireQueueGroup.convertToMov.helpTip = 'Adds a step that uses FFMPEG to convert the output to an uncompressed MOV file. You MUST set your export settings to an EXR sequence and have FFMPEG in the system path of your workers';
 
         // Create Ignore Missing Layers and Submit Project File group and widgets
         ignoreMissingLayersGroup = deadlineCloud.aeAdvancedOptionsPanel.add('group', undefined);
@@ -1076,9 +1081,10 @@ function __generateSubmitterUI() {
         }
 
         // Export as XML functionality + update
-        ignoreMissingLayersGroup.exportAsXml.onClick = function() {
-            makeClickHandler("ExportAsXml", ignoreMissingLayersGroup.exportAsXml, dcUtil.toBooleanString);
-        }
+        ignoreMissingLayersGroup.exportAsXml.onClick = makeClickHandler("ExportAsXml", ignoreMissingLayersGroup.exportAsXml, dcUtil.toBooleanString);
+        
+        // Convert to MOV
+        submitEntireQueueGroup.convertToMov.onClick = makeClickHandler("ConvertToMov", submitEntireQueueGroup.convertToMov, dcUtil.toBooleanString);
 
         // delete temp xml functionality + update
         ignoreMissingEffectsGroup.deleteTempXml.onClick = function() {

--- a/src/deadline/ae_submitter/UI/SubmitButton.jsx
+++ b/src/deadline/ae_submitter/UI/SubmitButton.jsx
@@ -535,6 +535,8 @@ function __generateSubmitButton() {
             if(submitEntireQueueGroup.convertToMov.value){
                 var convertStep = dcUtil.deepCopy(OPENJD_CONVERT_TO_MOV_STEP);
                 var dep = {"dependsOn": __compName};
+                var fps = __renderQueueItem.comp.frameRate
+                convertStep.script.embeddedFiles[0].data.replace("_FPS_", fps)
                 convertStep.dependencies.push(dep);
                 convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputFilePath}}", "{{Param." + __compName +"_OutputFilePath}}")
                 convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputPattern}}", "{{Param." + __compName +"_OutputPattern}}")
@@ -610,6 +612,8 @@ function __generateSubmitButton() {
         if(submitEntireQueueGroup.convertToMov.value){
             var convertStep = dcUtil.deepCopy(OPENJD_CONVERT_TO_MOV_STEP);
             var dep = {"dependsOn": itemName};
+            var fps = renderQueueItem.comp.frameRate
+            convertStep.script.embeddedFiles[0].data.replace("_FPS_", fps)
             convertStep.dependencies.push(dep);
             convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputFilePath}}", "{{Param." + itemName + "_OutputFilePath}}");
             convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputFilePath}}", "{{Param." + itemName + "_OutputFilePath}}");

--- a/src/deadline/ae_submitter/UI/SubmitButton.jsx
+++ b/src/deadline/ae_submitter/UI/SubmitButton.jsx
@@ -530,6 +530,17 @@ function __generateSubmitButton() {
             jobParams.parameterValues.push(applyDataToParameterTemplate(__compName + "_OutputFilePath", getCompleteDirectory(app.project.renderQueue.item(j))));
             
             stepIndex++;
+
+            //Add MOV step
+            if(submitEntireQueueGroup.convertToMov.value){
+                var convertStep = dcUtil.deepCopy(OPENJD_CONVERT_TO_MOV_STEP);
+                var dep = {"dependsOn": __compName};
+                convertStep.dependencies.push(dep);
+                convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputFilePath}}", "{{Param." + __compName +"_OutputFilePath}}")
+                convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputPattern}}", "{{Param." + __compName +"_OutputPattern}}")
+                convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputFormat}}", "{{Param." + __compName +"_OutputFormat}}")
+                jobTemplate.steps.push(convertStep);
+            }
         }
 
         return {
@@ -595,6 +606,16 @@ function __generateSubmitButton() {
             jobTemplate.parameterDefinitions.push(applyDataToTemplate(itemName + "_CompName", dcDataTemplate.CompName));
             jobParams.parameterValues.push(applyDataToParameterTemplate(itemName + "_CompName", renderQueueItem.comp.name));
         }
+        //Add MOV step
+        if(submitEntireQueueGroup.convertToMov.value){
+            var convertStep = dcUtil.deepCopy(OPENJD_CONVERT_TO_MOV_STEP);
+            var dep = {"dependsOn": itemName};
+            convertStep.dependencies.push(dep);
+            convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputFilePath}}", "{{Param." + itemName + "_OutputFilePath}}");
+            convertStep.script.embeddedFiles[0].data = convertStep.script.embeddedFiles[0].data.replace("{{Param.OutputFilePath}}", "{{Param." + itemName + "_OutputFilePath}}");
+            jobTemplate.steps.push(convertStep);
+        }
+        
         return {
             "jobTemplate": jobTemplate,
             "jobParams": jobParams

--- a/src/deadline/ae_submitter/data/InitData.jsx
+++ b/src/deadline/ae_submitter/data/InitData.jsx
@@ -98,6 +98,9 @@ function __generateInitData()
     function _generateFontReferences() {
         var fontLocations = [];
         var usedList = app.project.usedFonts;
+        if (usedList == null){
+            return fontLocations;
+        }
         for (var i = 0; i < usedList.length; i++) {
             var font = usedList[i].font;
             var fontFamilyName = font.familyName;

--- a/src/deadline/ae_submitter/submission/JobTemplate.jsx
+++ b/src/deadline/ae_submitter/submission/JobTemplate.jsx
@@ -349,3 +349,42 @@ var OPENJD_TEMPLATE_LAYER = {
         }
     }]
 }
+
+
+var OPENJD_CONVERT_TO_MOV_STEP = {
+    "name": "FFMPEG Convert to MOV",
+    "dependencies" : [],
+    "script": {
+        "actions": {
+            "onRun": {
+                "command": "powershell",
+                "args": [
+                    "{{Task.File.runScript}}"
+                ]
+            }
+        },
+        "embeddedFiles": [
+            {
+                "name": "runScript",
+                "filename": "convertToMov.ps1",
+                "type": "TEXT",
+                "runnable": true,
+                "data": "\
+                $ffmpeg = if ($null -ne $env:FFMPEG_EXE) { $env:FFMPEG_EXE } else { 'ffmpeg' }\
+                $original_path = '{{Param.OutputFilePath}}\\'\
+                $original_output = '{{Param.OutputPattern}}'\
+                $original_ext = '{{Param.OutputFormat}}'\
+                $sequence_regex = $original_output + '.' + $original_ext -replace '\\[#+\\]', '([0-9]+)'\
+                cd $original_path\
+                $sequence = Get-ChildItem | Where-Object Name -Match $sequence_regex\
+                $frame_match =  $sequence[0].Name | Select-String -Pattern $sequence_regex\
+                $frame_start = $frame_match.Matches[0].Groups[1].Value\
+                $frame_length = $frame_start.Length\
+                $frame_str = '%0{0}d' -f $frame_length\
+                $exr_str = $sequence_regex.Replace('([0-9]+)', $frame_str)\
+                $mov_str = $original_output + '.mov' -replace '\\[#+\\]', ''\
+                & $ffmpeg -start_number $frame_start -framerate 24 -i $exr_str -vcodec v210 -pix_fmt yuv422p10le $mov_str\n"
+            }
+        ]
+    }
+}

--- a/src/deadline/ae_submitter/submission/JobTemplate.jsx
+++ b/src/deadline/ae_submitter/submission/JobTemplate.jsx
@@ -383,7 +383,7 @@ var OPENJD_CONVERT_TO_MOV_STEP = {
                 $frame_str = '%0{0}d' -f $frame_length\
                 $exr_str = $sequence_regex.Replace('([0-9]+)', $frame_str)\
                 $mov_str = $original_output + '.mov' -replace '\\[#+\\]', ''\
-                & $ffmpeg -start_number $frame_start -framerate 24 -i $exr_str -vcodec v210 -pix_fmt yuv422p10le $mov_str\n"
+                & $ffmpeg -start_number $frame_start -framerate _FPS_ -i $exr_str -vcodec v210 -pix_fmt yuv422p10le $mov_str\n"
             }
         ]
     }


### PR DESCRIPTION
# What was the problem/requirement? (What/Why)

Mov renders were taking a very long time and occasionally failing due to spot interruptions. By rendering to an image sequence we are able to spread that work across many different workers to speed up the render and make the render resilient to spot interruptions.

# What was the solution? (How)

New submitter has a checkbox that adds a custom OpenJD step that converts everything to mov. Requires ffmpeg to be installed on the render workers and either be available from PATH or have its path defined under FFMPEG_EXE
What is the impact of this change?

Mov renders are going to be significantly more reliable and faster.

# How was this change tested?

I pushed a couple of renders to my own farm.

# Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

I don't know where these tests are or how to run them.

# Was this change documented?

no

# Is this a breaking change?

no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
